### PR TITLE
Feature/entitiy builder 16

### DIFF
--- a/src/main/java/com/gg/mafia/domain/achievement/domain/UserAchievement.java
+++ b/src/main/java/com/gg/mafia/domain/achievement/domain/UserAchievement.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(
@@ -36,6 +35,11 @@ public class UserAchievement extends BaseEntity {
     @ManyToOne(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Achievement achievement;
+
+    public UserAchievement(User user, Achievement achievement) {
+        this.user = user;
+        this.achievement = achievement;
+    }
 
     public static UserAchievement relate(User user, Achievement achievement) {
         UserAchievement userAchievement = new UserAchievement();

--- a/src/main/java/com/gg/mafia/domain/member/domain/UserToRole.java
+++ b/src/main/java/com/gg/mafia/domain/member/domain/UserToRole.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +19,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(
@@ -34,6 +34,12 @@ public class UserToRole extends BaseEntity {
     @ManyToOne(cascade = {CascadeType.PERSIST})
     @JoinColumn(nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Role role;
+
+    public UserToRole(User user, Role role) {
+        setUser(user);
+        setRole(role);
+    }
+
 
     public static UserToRole relate(User user, Role role) {
         UserToRole userToRole = new UserToRole();

--- a/src/test/java/com/gg/mafia/domain/achievement/domain/AchievementTest.java
+++ b/src/test/java/com/gg/mafia/domain/achievement/domain/AchievementTest.java
@@ -42,9 +42,9 @@ public class AchievementTest {
     @DisplayName("UserAchievement를 저장하면 User와 Achivement가 저장된다.")
     public void saveCascade() {
         UserAchievement userAchievement = UserAchievement.builder()
+                .user(createUser())
                 .achievement(createAchievement())
                 .build();
-        userAchievement.setUser(createUser());
         em.persist(userAchievement);
         em.flush();
         String userJpql = String.format("select u from User u where u.email = 'TEST_USER'");


### PR DESCRIPTION
### feat: 엔티티 릴레이션쉽 편의함수에 빌더 패턴 호환

기존에는 엔티티를 빌더 패턴으로 생성할 때 연관 엔티티 객체를 빌더로 넣으면 편의함수 setter가 실행되지 않는 문제가 있음
편의함수 setter를 사용하는 생성자를 직접 생성하여 빌더 패턴 실행 시 적용되도록 변경함

### refactor: AchievementTest.java 테스트 코드 변경

편의함수를 빌더 패턴에 호환 시키면서 가능해진 동작을 테스트 코드에 적용함