### PR TITLE
Feature/oauth google 47

### DIFF
--- a/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
@@ -1,15 +1,22 @@
 package com.gg.mafia.domain.member.api;
 
 import com.gg.mafia.domain.member.application.AuthService;
+import com.gg.mafia.domain.member.application.OAuthService;
 import com.gg.mafia.domain.member.dto.LoginRequest;
 import com.gg.mafia.domain.member.dto.SignupRequest;
 import com.gg.mafia.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthApi {
     private final AuthService authService;
+    private final OAuthService oAuthService;
+    private final Environment env;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Validated SignupRequest request) {
@@ -28,5 +37,20 @@ public class AuthApi {
     public ResponseEntity<ApiResponse<String>> authenticate(@RequestBody @Validated LoginRequest request) {
         String result = authService.authenticate(request);
         return ResponseEntity.ok().body(ApiResponse.success(result));
+    }
+
+    @GetMapping("/oauth-types/{oAuthType}/validate-oauth2-code")
+    public void validateOAuth2Code(
+            @RequestParam String code,
+            @PathVariable String oAuthType,
+            HttpServletResponse response
+    ) throws IOException {
+        String redirectUrl = env.getProperty("front-uri");
+        try {
+            String token = oAuthService.signupOrLoginByCode(code, oAuthType);
+            response.sendRedirect("%s?token=%s".formatted(redirectUrl, token));
+        } catch (Exception e) {
+            response.sendRedirect("%s?error=%s".formatted(redirectUrl, e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/gg/mafia/domain/member/application/OAuthService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/OAuthService.java
@@ -1,0 +1,69 @@
+package com.gg.mafia.domain.member.application;
+
+import com.gg.mafia.domain.member.dao.UserDao;
+import com.gg.mafia.domain.member.domain.User;
+import com.gg.mafia.domain.member.dto.OAuthUserDto;
+import com.gg.mafia.domain.member.exception.SignupFailedException;
+import com.gg.mafia.global.config.security.jwt.TokenProvider;
+import com.gg.mafia.global.config.security.oauth.GoogleStrategy;
+import com.gg.mafia.global.config.security.oauth.OAuthStrategy;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OAuthService {
+    private final GoogleStrategy googleStrategy;
+    private final UserDao userDao;
+    private final TokenProvider tokenProvider;
+
+    public String signupOrLoginByCode(String code, String oAuthType) {
+        OAuthStrategy strategy = getStrategy(oAuthType);
+        String oAuthAccessToken = strategy.getAccessToken(code);
+        OAuthUserDto oAuthUserDto = strategy.getOAuthUser(oAuthAccessToken);
+        return signupOrLogin(oAuthUserDto);
+    }
+
+    private String signupOrLogin(OAuthUserDto oAuthUserDto) {
+        User user = getOrCreateUser(oAuthUserDto);
+        return tokenProvider.createToken(user.getEmail());
+    }
+
+    private OAuthStrategy getStrategy(String oAuthType) {
+        OAuthStrategy strategy;
+        if (oAuthType.equals(OAuthStrategy.GOOGLE)) {
+            strategy = googleStrategy;
+        } else {
+            throw new IllegalArgumentException("OAuth 타입 불명");
+        }
+        return strategy;
+    }
+
+    private User getOrCreateUser(OAuthUserDto oAuthUserDto) {
+        Optional<User> user = userDao.findByEmail(oAuthUserDto.getEmail());
+        if (user.isEmpty()) {
+            return createUser(oAuthUserDto);
+        }
+        validateOAuthUserType(user.get(), oAuthUserDto);
+        return user.get();
+    }
+
+    private User createUser(OAuthUserDto oAuthUserDto) {
+        User user = User.builder()
+                .email(oAuthUserDto.getEmail())
+                .password(oAuthUserDto.getStrategyCode())
+                .build();
+        userDao.save(user);
+        return user;
+    }
+
+    private void validateOAuthUserType(User user, OAuthUserDto oAuthUserDto) {
+        String strategyCode = user.getPassword();
+        if (!strategyCode.equals(oAuthUserDto.getStrategyCode())) {
+            throw new SignupFailedException();
+        }
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/member/dto/OAuthUserDto.java
+++ b/src/main/java/com/gg/mafia/domain/member/dto/OAuthUserDto.java
@@ -1,0 +1,16 @@
+package com.gg.mafia.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OAuthUserDto {
+    @NotBlank
+    @Email
+    private String email;
+
+    private String strategyCode;
+}

--- a/src/main/java/com/gg/mafia/domain/member/exception/SignupFailedException.java
+++ b/src/main/java/com/gg/mafia/domain/member/exception/SignupFailedException.java
@@ -1,0 +1,11 @@
+package com.gg.mafia.domain.member.exception;
+
+public class SignupFailedException extends RuntimeException {
+    public SignupFailedException() {
+        this("가입할 수 없는 유저입니다");
+    }
+
+    public SignupFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gg/mafia/global/config/network/RestTemplateConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/network/RestTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.gg.mafia.global.config.web;
+package com.gg.mafia.global.config.network;
 
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/gg/mafia/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/security/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                 new AntPathRequestMatcher("/**/api-docs/**"),
                 new AntPathRequestMatcher("/"),
                 new AntPathRequestMatcher("/member/authenticate"),
-                new AntPathRequestMatcher("/member/signup")
+                new AntPathRequestMatcher("/member/signup"),
+                new AntPathRequestMatcher("/member/oauth-types/**/validate-oauth2-code")
         };
         builder.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests

--- a/src/main/java/com/gg/mafia/global/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/gg/mafia/global/config/security/jwt/TokenProvider.java
@@ -41,13 +41,17 @@ public class TokenProvider {
         this.userMapper = userMapper;
     }
 
-    public String createToken(Authentication authentication) {
+    public String createToken(String email) {
         return Jwts.builder()
-                .setSubject(authentication.getName())
+                .setSubject(email)
                 .signWith(key, SignatureAlgorithm.HS512)
                 .setExpiration(getExpiration())
                 .setIssuedAt(new Date())
                 .compact();
+    }
+
+    public String createToken(Authentication authentication) {
+        return createToken(authentication.getName());
     }
 
     @Transactional

--- a/src/main/java/com/gg/mafia/global/config/security/oauth/GoogleStrategy.java
+++ b/src/main/java/com/gg/mafia/global/config/security/oauth/GoogleStrategy.java
@@ -1,0 +1,53 @@
+package com.gg.mafia.global.config.security.oauth;
+
+import com.gg.mafia.domain.member.dto.OAuthUserDto;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleStrategy implements OAuthStrategy {
+    private final Environment env;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("code", code);
+        requestBody.put("client_id", env.getProperty("google.client-id"));
+        requestBody.put("client_secret", env.getProperty("google.client-secret"));
+        requestBody.put("redirect_uri", env.getProperty("google.redirect-uri"));
+        requestBody.put("grant_type", "authorization_code");
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(requestBody, headers);
+
+        Map response = restTemplate.postForObject(
+                env.getProperty("google.token-uri", ""),
+                request,
+                Map.class
+        );
+
+        return (String) response.get("access_token");
+    }
+
+    @Override
+    public OAuthUserDto getOAuthUser(String accessToken) {
+        String url = "%s?access_token=%s".formatted(env.getProperty("google.user-info-uri"), accessToken);
+        Map response = restTemplate.getForObject(url, Map.class);
+        return OAuthUserDto.builder()
+                .email((String) response.get("email"))
+                .strategyCode(getStrategyCode())
+                .build();
+    }
+
+    @Override
+    public String getStrategyCode() {
+        return OAuthStrategy.GOOGLE;
+    }
+}

--- a/src/main/java/com/gg/mafia/global/config/security/oauth/OAuthStrategy.java
+++ b/src/main/java/com/gg/mafia/global/config/security/oauth/OAuthStrategy.java
@@ -1,0 +1,13 @@
+package com.gg.mafia.global.config.security.oauth;
+
+import com.gg.mafia.domain.member.dto.OAuthUserDto;
+
+public interface OAuthStrategy {
+    String GOOGLE = "google";
+
+    String getAccessToken(String code);
+
+    OAuthUserDto getOAuthUser(String accessToken);
+
+    String getStrategyCode();
+}

--- a/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.gg.mafia.global.error;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.gg.mafia.domain.member.exception.LoginFailedException;
+import com.gg.mafia.domain.member.exception.SignupFailedException;
 import com.gg.mafia.global.common.response.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.stream.Collectors;
@@ -48,7 +49,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(ApiResponse.error(message));
     }
 
-    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class, SignupFailedException.class})
     ResponseEntity<ApiResponse<Void>> handleBadRequestException(RuntimeException exception) {
         logger.error("message", exception);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/test/java/com/gg/mafia/sample/RestTemplateTest.java
+++ b/src/test/java/com/gg/mafia/sample/RestTemplateTest.java
@@ -1,7 +1,7 @@
 package com.gg.mafia.sample;
 
 
-import com.gg.mafia.global.config.web.RestTemplateConfig;
+import com.gg.mafia.global.config.network.RestTemplateConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## !!! 새로운 환경 변수 갱신 할 것 security.properties https://www.notion.so/30315b961d684a9abfbb7e6b738a7be8 

### feat: TokenProvider.java 토큰 발급 함수 오버로드

- createToken(String email): 이메일로 JWT 토큰을 생성하는 함수를 추가함

### feat: 회원가입 에러 핸들링 추가

### refactor: RestTemplateConfig.java 패키지 변경

### feat: OAuth 전략 패턴 구현

OAuth 전략에 따라 다른 인증 로직을 수행할 수 있도록 구현
- OAuthService: 인증 전략 인터페이스
- OAuthUserDto: OAuthStrategy 에서 사용하는 인증 정보를 담는 DTO
- GoogleStrategy: 인증 전략 구현체

### feat: OAuthService 구현

OAuthService 구현
- 여러 인증 전략 타입에 따라 다른 인증 로직 수행
- 유저 존재 여부에 따라 로그인 또는 회원가입을 진행 후 자체 JWT 토큰 발급

### feat: AuthApi 에 OAuth 인증 API 추가

- 요청 인증 타입에 따라 OAuthService 내부에서 다른 인증 전략 분기
- 인증 성공 시 자체 JWT 토큰을 프론트 페이지 경로 쿼리 파라미터에 넣어 리다이렉트
- 인증 실패 시 에러 메시지를 프론트 페이지 경로 쿼리 파라미터에 넣어 리다이렉트
- SecurityConfig: OAuth API 를 인증 없이 접근 가능하도록 허용
