### PR TITLE
Feature/throttling 53

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,10 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.2")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.2")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.2")
+
+    // Email 인증
+    implementation "javax.mail:mail:1.4.7"
+    implementation "org.springframework:spring-context-support:5.3.9"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ dependencies {
     implementation "javax.mail:mail:1.4.7"
     implementation "org.springframework:spring-context-support:5.3.9"
     implementation 'com.bucket4j:bucket4j-core:8.3.0'
+    implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
     implementation "io.jsonwebtoken:jjwt-api:0.11.2"
     implementation "io.jsonwebtoken:jjwt-impl:0.11.2"
     implementation "io.jsonwebtoken:jjwt-jackson:0.11.2"

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     // Email 인증
     implementation "javax.mail:mail:1.4.7"
     implementation "org.springframework:spring-context-support:5.3.9"
+    implementation 'com.bucket4j:bucket4j-core:8.3.0'
 }
 
 test {

--- a/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
@@ -7,6 +7,7 @@ import com.gg.mafia.domain.member.dto.LoginRequest;
 import com.gg.mafia.domain.member.dto.SendMailRequest;
 import com.gg.mafia.domain.member.dto.SignupRequest;
 import com.gg.mafia.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -37,8 +38,15 @@ public class AuthApi {
     }
 
     @PostMapping("/sendMail")
-    public ResponseEntity<ApiResponse<String>> sendMail(@RequestBody @Validated SendMailRequest request){
-        String authCode = mailService.sendEmail(request);
+    public ResponseEntity<ApiResponse<String>> sendMail(@RequestBody @Validated SendMailRequest request, HttpServletRequest servletRequest){
+        String clientIP = servletRequest.getHeader("X-Forwarded-For");
+
+        // X-Forwarded-For 헤더가 없거나 비어 있는 경우, 클라이언트의 IP 주소는 remoteAddr로부터 가져옴
+        if (clientIP == null || clientIP.isEmpty()) {
+            clientIP = servletRequest.getRemoteAddr();
+        }
+
+        String authCode = mailService.sendEmail(request, clientIP);
         return ResponseEntity.ok().body(ApiResponse.success(authCode));
     }
 

--- a/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
@@ -6,6 +6,7 @@ import com.gg.mafia.domain.member.dto.ConfirmMailRequest;
 import com.gg.mafia.domain.member.dto.LoginRequest;
 import com.gg.mafia.domain.member.dto.SendMailRequest;
 import com.gg.mafia.domain.member.dto.SignupRequest;
+import com.gg.mafia.domain.member.exception.UserNotAllowedException;
 import com.gg.mafia.global.common.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,9 @@ public class AuthApi {
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Validated SignupRequest request) {
+        if(!mailService.confirmMail(request.getEmail(),request.getEmailCode())){
+            throw new UserNotAllowedException("인증되지 않은 사용자입니다.");
+        }
         authService.signup(request);
         return ResponseEntity.ok().build();
     }
@@ -52,7 +56,7 @@ public class AuthApi {
 
     @PostMapping("/confirmMail")
     public ResponseEntity<ApiResponse<Boolean>> confirmMail(@RequestBody @Validated ConfirmMailRequest request){
-        Boolean isCodeMatching = mailService.confirmMail(request);
+        Boolean isCodeMatching = mailService.confirmMail(request.getEmail(),request.getEmailCode());
         return ResponseEntity.ok().body(ApiResponse.success(isCodeMatching));
     }
 }

--- a/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
@@ -46,8 +46,8 @@ public class AuthApi {
             clientIP = servletRequest.getRemoteAddr();
         }
 
-        String authCode = mailService.sendEmail(request, clientIP);
-        return ResponseEntity.ok().body(ApiResponse.success(authCode));
+        mailService.sendEmail(request, clientIP);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/confirmMail")

--- a/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/AuthApi.java
@@ -1,7 +1,10 @@
 package com.gg.mafia.domain.member.api;
 
 import com.gg.mafia.domain.member.application.AuthService;
+import com.gg.mafia.domain.member.application.MailService;
+import com.gg.mafia.domain.member.dto.ConfirmMailRequest;
 import com.gg.mafia.domain.member.dto.LoginRequest;
+import com.gg.mafia.domain.member.dto.SendMailRequest;
 import com.gg.mafia.domain.member.dto.SignupRequest;
 import com.gg.mafia.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthApi {
     private final AuthService authService;
 
+    private final MailService mailService;
+
+
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Validated SignupRequest request) {
         authService.signup(request);
@@ -28,5 +34,17 @@ public class AuthApi {
     public ResponseEntity<ApiResponse<String>> authenticate(@RequestBody @Validated LoginRequest request) {
         String result = authService.authenticate(request);
         return ResponseEntity.ok().body(ApiResponse.success(result));
+    }
+
+    @PostMapping("/sendMail")
+    public ResponseEntity<ApiResponse<String>> sendMail(@RequestBody @Validated SendMailRequest request){
+        String authCode = mailService.sendEmail(request);
+        return ResponseEntity.ok().body(ApiResponse.success(authCode));
+    }
+
+    @PostMapping("/confirmMail")
+    public ResponseEntity<ApiResponse<Boolean>> confirmMail(@RequestBody @Validated ConfirmMailRequest request){
+        Boolean isCodeMatching = mailService.confirmMail(request);
+        return ResponseEntity.ok().body(ApiResponse.success(isCodeMatching));
     }
 }

--- a/src/main/java/com/gg/mafia/domain/member/application/MailService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/MailService.java
@@ -1,0 +1,73 @@
+package com.gg.mafia.domain.member.application;
+
+import com.gg.mafia.domain.member.dto.ConfirmMailRequest;
+import com.gg.mafia.domain.member.dto.SendMailRequest;
+import com.gg.mafia.domain.member.dto.UserMapper;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    @Autowired
+    private JavaMailSender mailSender;
+
+    private int authCode;
+    private UserMapper userMapper;
+
+    public void makeEmailAuthCode() {
+        Random rnd = new Random();
+        String randomNumber = "";
+        for(int i = 0; i < 6; i++) {
+            randomNumber += Integer.toString(rnd.nextInt(10));
+        }
+
+        authCode = Integer.parseInt(randomNumber);
+    }
+    public String sendEmail(SendMailRequest request) {
+        makeEmailAuthCode();
+        String setFromName = "MAFIA.GG";
+        String setFrom = "rkdwlgns1119@gmail.com"; // email-config에 설정한 자신의 이메일 주소를 입력
+        String toMail = request.getEmail();
+        String title = "회원 가입 인증 이메일 입니다."; // 이메일 제목
+        String content =
+                "<h1>MAFIA.GG에 오신 것을 환영합니다.</h1>" + 	//html 형식으로 작성 !
+                        "<br><br>" +
+                        "인증 번호는 " + authCode + "입니다." +
+                        "<br>" +
+                        "인증번호를 사이트에 입력해주세요."; //이메일 내용 삽입
+        mailSend(setFrom,setFromName, toMail, title, content);
+
+
+        return Integer.toString(authCode);
+    }
+
+    public void mailSend(String setFrom, String setFromName, String toMail, String title, String content) {
+        MimeMessage message = mailSender.createMimeMessage();//JavaMailSender 객체를 사용하여 MimeMessage 객체를 생성
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message,true,"utf-8");//이메일 메시지와 관련된 설정을 수행합니다.
+            // true를 전달하여 multipart 형식의 메시지를 지원하고, "utf-8"을 전달하여 문자 인코딩을 설정
+            helper.setFrom(setFrom,setFromName);//이메일의 발신자 주소 설정
+            helper.setTo(toMail);//이메일의 수신자 주소 설정
+            helper.setSubject(title);//이메일의 제목을 설정
+            helper.setText(content,true);//이메일의 내용 설정 두 번째 매개 변수에 true를 설정하여 html 설정으로한다.
+            mailSender.send(message);
+        } catch (MessagingException e) {//이메일 서버에 연결할 수 없거나, 잘못된 이메일 주소를 사용하거나, 인증 오류가 발생하는 등 오류
+            // 이러한 경우 MessagingException이 발생
+            e.printStackTrace();//e.printStackTrace()는 예외를 기본 오류 스트림에 출력하는 메서드
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Boolean confirmMail(ConfirmMailRequest request) {
+        return true;
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/member/application/MailService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/MailService.java
@@ -2,6 +2,7 @@ package com.gg.mafia.domain.member.application;
 
 import com.gg.mafia.domain.member.dao.UserDao;
 import com.gg.mafia.domain.member.dto.SendMailRequest;
+import com.gg.mafia.domain.member.exception.MailServerException;
 import com.gg.mafia.domain.member.exception.RequestThrottlingException;
 import com.gg.mafia.domain.member.exception.UserAlreadyExistsException;
 import java.io.UnsupportedEncodingException;
@@ -44,15 +45,15 @@ public class MailService {
 
         makeEmailAuthCode();
         String setFromName = "MAFIA.GG";
-        String setFrom = "rkdwlgns1119@gmail.com"; // email-config에 설정한 자신의 이메일 주소를 입력
+        String setFrom = "rkdwlgns1119@gmail.com";
         String toMail = request.getEmail();
-        String title = "회원 가입 인증 이메일 입니다."; // 이메일 제목
+        String title = "회원 가입 인증 이메일 입니다.";
         String content =
-                "<h1>MAFIA.GG에 오신 것을 환영합니다.</h1>" + 	//html 형식으로 작성 !
+                "<h1>MAFIA.GG에 오신 것을 환영합니다.</h1>" +
                         "<br><br>" +
                         "인증 번호는 " + authCode + "입니다." +
                         "<br>" +
-                        "인증번호를 사이트에 입력해주세요."; //이메일 내용 삽입
+                        "인증번호를 사이트에 입력해주세요.";
         mailSend(setFrom,setFromName, toMail, title, content, clientIP);
 
         redisTemplate.opsForValue().set(toMail, authCode,5, TimeUnit.MINUTES);
@@ -74,11 +75,10 @@ public class MailService {
                 throw new RequestThrottlingException("ip - "+clientIP+"= too many request");
             }
 
-        } catch (MessagingException e) {//이메일 서버에 연결할 수 없거나, 잘못된 이메일 주소를 사용하거나, 인증 오류가 발생하는 등 오류
-            // 이러한 경우 MessagingException이 발생
-            e.printStackTrace();//e.printStackTrace()는 예외를 기본 오류 스트림에 출력하는 메서드
+        } catch (MessagingException e) {
+            throw new MailServerException();
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            throw new IllegalArgumentException("인코딩 오류 발생");
         }
     }
 

--- a/src/main/java/com/gg/mafia/domain/member/application/MailService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/MailService.java
@@ -35,7 +35,7 @@ public class MailService {
 
         authCode = randomNumber;
     }
-    public String sendEmail(SendMailRequest request,String clientIP) {
+    public void sendEmail(SendMailRequest request,String clientIP) {
         makeEmailAuthCode();
         String setFromName = "MAFIA.GG";
         String setFrom = "rkdwlgns1119@gmail.com"; // email-config에 설정한 자신의 이메일 주소를 입력
@@ -51,7 +51,6 @@ public class MailService {
 
         redisTemplate.opsForValue().set(toMail, authCode,5, TimeUnit.MINUTES);
 
-        return authCode;
     }
 
     public void mailSend(String setFrom, String setFromName, String toMail, String title, String content,String clientIP) {
@@ -80,7 +79,7 @@ public class MailService {
     public Boolean confirmMail(ConfirmMailRequest request) {
         String authCode = (String)redisTemplate.opsForValue().get(request.getEmail());
 
-        return request.getEmailAuthCode().equals(authCode);
+        return request.getEmailCode().equals(authCode);
     }
 
 }

--- a/src/main/java/com/gg/mafia/domain/member/application/MailService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/MailService.java
@@ -12,6 +12,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -28,6 +29,7 @@ public class MailService {
     private RedisTemplate<String,Object> redisTemplate;
     private String authCode;
     private final UserDao userDao;
+    private final Environment env;
 
     public void makeEmailAuthCode() {
         Random rnd = new Random();
@@ -45,7 +47,7 @@ public class MailService {
 
         makeEmailAuthCode();
         String setFromName = "MAFIA.GG";
-        String setFrom = "rkdwlgns1119@gmail.com";
+        String setFrom = env.getProperty("mail.username");
         String toMail = request.getEmail();
         String title = "회원 가입 인증 이메일 입니다.";
         String content =

--- a/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
@@ -1,0 +1,26 @@
+package com.gg.mafia.domain.member.application;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Refill;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ThrottlingService {
+     private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public boolean allowRequest(String ipAddress) {
+        Bucket bucket = buckets.computeIfAbsent(ipAddress, k -> createBucket());
+
+        return bucket.tryConsume(1);
+    }
+
+    private Bucket createBucket() {
+        Bandwidth limit = Bandwidth.classic(30, Refill.intervally(10, Duration.ofSeconds(1)));
+        return Bucket4j.builder().addLimit(limit).build();
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ThrottlingService {
     private static final int MAX_TOTAL_BUCKETS = 100; // 최대 버킷 수
-    private static final int DELETE_BUCKETS = 10; // 삭제할 버킷 개수
 
     private static final int MAX_IP_BUCKETS = 10; // ip당 최대 버킷 수
      private final Map<String, Bucket> buckets = new ConcurrentLinkedHashMap.Builder<String, Bucket>()
@@ -38,9 +37,7 @@ public class ThrottlingService {
         return MAX_TOTAL_BUCKETS;
     }
 
-    public int getDeleteBuckets() {
-        return DELETE_BUCKETS;
-    }
+
     public int getMAxIpBuckets() {
         return MAX_IP_BUCKETS;
     }

--- a/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
+++ b/src/main/java/com/gg/mafia/domain/member/application/ThrottlingService.java
@@ -11,16 +11,69 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ThrottlingService {
+    private static final int MAX_TOTAL_BUCKETS = 100; // 최대 버킷 수
+    private static final int DELETE_BUCKETS = 10; // 삭제할 버킷 개수
+
+    private static final int MAX_IP_BUCKETS = 10; // ip당 최대 버킷 수
      private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
 
     public boolean allowRequest(String ipAddress) {
         Bucket bucket = buckets.computeIfAbsent(ipAddress, k -> createBucket());
 
+        if (buckets.size() >= MAX_TOTAL_BUCKETS) {
+            //삭제함수 구현
+            removeOldestBucket(DELETE_BUCKETS);
+        }
+
         return bucket.tryConsume(1);
     }
 
     private Bucket createBucket() {
-        Bandwidth limit = Bandwidth.classic(30, Refill.intervally(10, Duration.ofSeconds(1)));
+        Bandwidth limit = Bandwidth.classic(MAX_IP_BUCKETS, Refill.intervally(1, Duration.ofSeconds(1)));
         return Bucket4j.builder().addLimit(limit).build();
     }
+
+    public Map<String, Bucket> getBuckets() {
+        return buckets;
+    }
+
+    public int getMaxTotalBuckets() {
+        return MAX_TOTAL_BUCKETS;
+    }
+
+    public int getDeleteBuckets() {
+        return DELETE_BUCKETS;
+    }
+    public int getMAxIpBuckets() {
+        return MAX_IP_BUCKETS;
+    }
+
+    private void removeOldestBucket(int deleteCount) {
+        for (int i = 0; i < deleteCount; i++) {
+            String oldestBucketKey = null;
+            long maxTokens = Long.MIN_VALUE;
+
+            // 가장 많은 토큰을 가진 버킷 찾기
+            for (Map.Entry<String, Bucket> entry : buckets.entrySet()) {
+                Bucket bucket = entry.getValue();
+                long availableTokens = bucket.getAvailableTokens();
+                if (availableTokens > maxTokens) {
+                    maxTokens = availableTokens;
+                    oldestBucketKey = entry.getKey();
+                }
+            }
+
+            // 가장 많은 토큰을 가진 버킷 삭제
+            if (oldestBucketKey != null) {
+                buckets.remove(oldestBucketKey);
+            } else {
+                break;
+            }
+        }
+
+
+    }
+
+
+
 }

--- a/src/main/java/com/gg/mafia/domain/member/domain/User.java
+++ b/src/main/java/com/gg/mafia/domain/member/domain/User.java
@@ -28,6 +28,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column
+    private String nickname;
+
     @OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST,
             CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<UserToRole> userToRoles = new ArrayList<>();

--- a/src/main/java/com/gg/mafia/domain/member/dto/ConfirmMailRequest.java
+++ b/src/main/java/com/gg/mafia/domain/member/dto/ConfirmMailRequest.java
@@ -11,5 +11,5 @@ public class ConfirmMailRequest {
     private String email;
 
     @NotBlank
-    private String emailAuthCode;
+    private String emailCode;
 }

--- a/src/main/java/com/gg/mafia/domain/member/dto/ConfirmMailRequest.java
+++ b/src/main/java/com/gg/mafia/domain/member/dto/ConfirmMailRequest.java
@@ -1,0 +1,15 @@
+package com.gg.mafia.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ConfirmMailRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String emailAuthCode;
+}

--- a/src/main/java/com/gg/mafia/domain/member/dto/SendMailRequest.java
+++ b/src/main/java/com/gg/mafia/domain/member/dto/SendMailRequest.java
@@ -1,0 +1,12 @@
+package com.gg.mafia.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SendMailRequest {
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/gg/mafia/domain/member/dto/SignupRequest.java
+++ b/src/main/java/com/gg/mafia/domain/member/dto/SignupRequest.java
@@ -14,4 +14,10 @@ public class SignupRequest {
     @NotBlank
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,20}$")
     private String password;
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String emailCode;
 }

--- a/src/main/java/com/gg/mafia/domain/member/exception/MailServerException.java
+++ b/src/main/java/com/gg/mafia/domain/member/exception/MailServerException.java
@@ -1,0 +1,11 @@
+package com.gg.mafia.domain.member.exception;
+
+public class MailServerException extends RuntimeException {
+    public MailServerException() {
+        this("메일서버의 오류");
+    }
+
+    public MailServerException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/member/exception/RequestThrottlingException.java
+++ b/src/main/java/com/gg/mafia/domain/member/exception/RequestThrottlingException.java
@@ -1,0 +1,11 @@
+package com.gg.mafia.domain.member.exception;
+
+public class RequestThrottlingException extends RuntimeException {
+    public RequestThrottlingException() {
+        this("요청 한계를 초과하였습니다.");
+    }
+
+    public RequestThrottlingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/member/exception/UserAlreadyExistsException.java
+++ b/src/main/java/com/gg/mafia/domain/member/exception/UserAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.gg.mafia.domain.member.exception;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException() {
+        this("이미 존재하는 사용자입니다.");
+    }
+
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gg/mafia/global/config/AppConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/AppConfig.java
@@ -11,7 +11,8 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
         @PropertySource("classpath:config/db.properties"),
         @PropertySource("classpath:config/application.properties"),
         @PropertySource("classpath:config/swagger.properties"),
-        @PropertySource("classpath:config/security.properties")
+        @PropertySource("classpath:config/security.properties"),
+        @PropertySource("classpath:config/email.properties")
 })
 public class AppConfig {
     @Bean

--- a/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
@@ -16,19 +16,19 @@ public class EmailConfig {
     public JavaMailSender mailSender() {
 
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost(env.getProperty("spring.mail.host"));// SMTP 서버 호스트 설정
-        mailSender.setPort(Integer.parseInt(env.getProperty("spring.mail.port")));// 포트지정
-        mailSender.setUsername(env.getProperty("spring.mail.username"));//구글계정
-        mailSender.setPassword(env.getProperty("spring.mail.password"));//구글 앱 비밀번호
+        mailSender.setHost(env.getProperty("mail.host"));// SMTP 서버 호스트 설정
+        mailSender.setPort(Integer.parseInt(env.getProperty("mail.port")));// 포트지정
+        mailSender.setUsername(env.getProperty("mail.username"));//구글계정
+        mailSender.setPassword(env.getProperty("mail.password"));//구글 앱 비밀번호
 
         Properties javaMailProperties = new Properties();
-        javaMailProperties.put("mail.transport.protocol", env.getProperty("spring.mail.protocol"));//프로토콜로 smtp 사용
-        javaMailProperties.put("mail.smtp.auth",env.getProperty("spring.mail.smtp.auth"));//smtp 서버에 인증이 필요
-        javaMailProperties.put("mail.smtp.socketFactory.class", env.getProperty("spring.mail.socketFactory.class"));//SSL 소켓 팩토리 클래스 사용
-        javaMailProperties.put("mail.smtp.starttls.enable",env.getProperty("spring.mail.starttls.enable"));//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
-        javaMailProperties.put("mail.debug", env.getProperty("spring.mail.debug"));//디버깅 정보 출력
-        javaMailProperties.put("mail.smtp.ssl.trust", env.getProperty("spring.mail.ssl.trust"));//smtp 서버의 ssl 인증서를 신뢰
-        javaMailProperties.put("mail.smtp.ssl.protocols", env.getProperty("spring.mail.ssl.protocols"));//사용할 ssl 프로토콜 버젼
+        javaMailProperties.put("mail.transport.protocol", env.getProperty("mail.protocol"));//프로토콜로 smtp 사용
+        javaMailProperties.put("mail.smtp.auth",env.getProperty("mail.smtp.auth"));//smtp 서버에 인증이 필요
+        javaMailProperties.put("mail.smtp.socketFactory.class", env.getProperty("mail.socketFactory.class"));//SSL 소켓 팩토리 클래스 사용
+        javaMailProperties.put("mail.smtp.starttls.enable",env.getProperty("mail.starttls.enable"));//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
+        javaMailProperties.put("mail.debug", env.getProperty("mail.debug"));//디버깅 정보 출력
+        javaMailProperties.put("mail.smtp.ssl.trust", env.getProperty("mail.ssl.trust"));//smtp 서버의 ssl 인증서를 신뢰
+        javaMailProperties.put("mail.smtp.ssl.protocols", env.getProperty("mail.ssl.protocols"));//사용할 ssl 프로토콜 버젼
 
         mailSender.setJavaMailProperties(javaMailProperties);
 

--- a/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
@@ -1,0 +1,32 @@
+package com.gg.mafia.global.config.auth;
+
+import java.util.Properties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+@Configuration
+public class EmailConfig {
+    @Bean
+    public JavaMailSender mailSender() {//JAVA MAILSENDER 인터페이스를 구현한 객체를 빈으로 등록하기 위함.
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();//JavaMailSender 의 구현체를 생성하고
+        mailSender.setHost("smtp.gmail.com");// 속성을 넣기 시작합니다. 이메일 전송에 사용할 SMTP 서버 호스트를 설정
+        mailSender.setPort(587);// 587로 포트를 지정
+        mailSender.setUsername("rkdwlgns1119@gmail.com");//구글계정을 넣습니다.
+        mailSender.setPassword("uxqa gsrc bzfs ducy");//구글 앱 비밀번호를 넣습니다.
+
+        Properties javaMailProperties = new Properties();//JavaMail의 속성을 설정하기 위해 Properties 객체를 생성
+        javaMailProperties.put("mail.transport.protocol", "smtp");//프로토콜로 smtp 사용
+        javaMailProperties.put("mail.smtp.auth", "true");//smtp 서버에 인증이 필요
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");//SSL 소켓 팩토리 클래스 사용
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
+        javaMailProperties.put("mail.debug", "true");//디버깅 정보 출력
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.naver.com");//smtp 서버의 ssl 인증서를 신뢰
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");//사용할 ssl 프로토콜 버젼
+
+        mailSender.setJavaMailProperties(javaMailProperties);//mailSender에 우리가 만든 properties 넣고
+
+        return mailSender;//빈으로 등록한다.
+    }
+}

--- a/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/auth/EmailConfig.java
@@ -1,32 +1,37 @@
 package com.gg.mafia.global.config.auth;
 
 import java.util.Properties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+
 @Configuration
 public class EmailConfig {
+    @Autowired
+    Environment env;
     @Bean
-    public JavaMailSender mailSender() {//JAVA MAILSENDER 인터페이스를 구현한 객체를 빈으로 등록하기 위함.
+    public JavaMailSender mailSender() {
 
-        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();//JavaMailSender 의 구현체를 생성하고
-        mailSender.setHost("smtp.gmail.com");// 속성을 넣기 시작합니다. 이메일 전송에 사용할 SMTP 서버 호스트를 설정
-        mailSender.setPort(587);// 587로 포트를 지정
-        mailSender.setUsername("rkdwlgns1119@gmail.com");//구글계정을 넣습니다.
-        mailSender.setPassword("uxqa gsrc bzfs ducy");//구글 앱 비밀번호를 넣습니다.
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(env.getProperty("spring.mail.host"));// SMTP 서버 호스트 설정
+        mailSender.setPort(Integer.parseInt(env.getProperty("spring.mail.port")));// 포트지정
+        mailSender.setUsername(env.getProperty("spring.mail.username"));//구글계정
+        mailSender.setPassword(env.getProperty("spring.mail.password"));//구글 앱 비밀번호
 
-        Properties javaMailProperties = new Properties();//JavaMail의 속성을 설정하기 위해 Properties 객체를 생성
-        javaMailProperties.put("mail.transport.protocol", "smtp");//프로토콜로 smtp 사용
-        javaMailProperties.put("mail.smtp.auth", "true");//smtp 서버에 인증이 필요
-        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");//SSL 소켓 팩토리 클래스 사용
-        javaMailProperties.put("mail.smtp.starttls.enable", "true");//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
-        javaMailProperties.put("mail.debug", "true");//디버깅 정보 출력
-        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.naver.com");//smtp 서버의 ssl 인증서를 신뢰
-        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");//사용할 ssl 프로토콜 버젼
+        Properties javaMailProperties = new Properties();
+        javaMailProperties.put("mail.transport.protocol", env.getProperty("spring.mail.protocol"));//프로토콜로 smtp 사용
+        javaMailProperties.put("mail.smtp.auth",env.getProperty("spring.mail.smtp.auth"));//smtp 서버에 인증이 필요
+        javaMailProperties.put("mail.smtp.socketFactory.class", env.getProperty("spring.mail.socketFactory.class"));//SSL 소켓 팩토리 클래스 사용
+        javaMailProperties.put("mail.smtp.starttls.enable",env.getProperty("spring.mail.starttls.enable"));//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
+        javaMailProperties.put("mail.debug", env.getProperty("spring.mail.debug"));//디버깅 정보 출력
+        javaMailProperties.put("mail.smtp.ssl.trust", env.getProperty("spring.mail.ssl.trust"));//smtp 서버의 ssl 인증서를 신뢰
+        javaMailProperties.put("mail.smtp.ssl.protocols", env.getProperty("spring.mail.ssl.protocols"));//사용할 ssl 프로토콜 버젼
 
-        mailSender.setJavaMailProperties(javaMailProperties);//mailSender에 우리가 만든 properties 넣고
+        mailSender.setJavaMailProperties(javaMailProperties);
 
-        return mailSender;//빈으로 등록한다.
+        return mailSender;
     }
 }

--- a/src/main/java/com/gg/mafia/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/security/SecurityConfig.java
@@ -47,7 +47,9 @@ public class SecurityConfig {
                 new AntPathRequestMatcher("/**/api-docs/**"),
                 new AntPathRequestMatcher("/"),
                 new AntPathRequestMatcher("/member/authenticate"),
-                new AntPathRequestMatcher("/member/signup")
+                new AntPathRequestMatcher("/member/signup"),
+                new AntPathRequestMatcher("/member/sendMail"),
+                new AntPathRequestMatcher("/member/confirmMail")
         };
         builder.authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests

--- a/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.gg.mafia.global.error;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.gg.mafia.domain.member.exception.LoginFailedException;
 import com.gg.mafia.domain.member.exception.RequestThrottlingException;
+import com.gg.mafia.domain.member.exception.UserAlreadyExistsException;
 import com.gg.mafia.global.common.response.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.stream.Collectors;
@@ -74,6 +75,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ResponseEntity<ApiResponse<Void>> handleRequestThrottlingException(RequestThrottlingException exception) {
         logger.error("message", exception);
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(ApiResponse.error(exception.getMessage()));
+    }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    ResponseEntity<ApiResponse<Void>> handleUserAlreadyExistsException(UserAlreadyExistsException exception) {
+        logger.error("message", exception);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(exception.getMessage()));
     }
 

--- a/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.gg.mafia.global.error;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.gg.mafia.domain.member.exception.LoginFailedException;
+import com.gg.mafia.domain.member.exception.RequestThrottlingException;
 import com.gg.mafia.global.common.response.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.stream.Collectors;
@@ -66,6 +67,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ResponseEntity<ApiResponse<Void>> handleUnauthorizedException(LoginFailedException exception) {
         logger.error("message", exception);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(exception.getMessage()));
+    }
+
+    @ExceptionHandler(RequestThrottlingException.class)
+    ResponseEntity<ApiResponse<Void>> handleRequestThrottlingException(RequestThrottlingException exception) {
+        logger.error("message", exception);
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
                 .body(ApiResponse.error(exception.getMessage()));
     }
 

--- a/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/gg/mafia/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.gg.mafia.global.error;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.gg.mafia.domain.member.exception.LoginFailedException;
+import com.gg.mafia.domain.member.exception.MailServerException;
 import com.gg.mafia.domain.member.exception.RequestThrottlingException;
 import com.gg.mafia.domain.member.exception.UserAlreadyExistsException;
 import com.gg.mafia.global.common.response.ApiResponse;
@@ -106,7 +107,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 //                .body(ApiResponse.error(exception.getMessage()));
 //    }
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler({Exception.class, MailServerException.class})
     ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception exception) {
         logger.error("message", exception);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/test/java/com/gg/mafia/sample/ThrottlingTest.java
+++ b/src/test/java/com/gg/mafia/sample/ThrottlingTest.java
@@ -1,0 +1,95 @@
+package com.gg.mafia.sample;
+
+import com.gg.mafia.domain.member.application.ThrottlingService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class ThrottlingTest {
+    private ThrottlingService throttlingService = new ThrottlingService();
+
+    @Test
+    public void testMaxConcurrentRequests() throws InterruptedException {
+
+        // 다수의 클라이언트 IP 주소를 시뮬레이트
+        String[] clientIPs = {"192.168.1.1", "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5"};
+        int clients = clientIPs.length;
+        int requestCount = 13 ; // 각 스레드가 보낼 요청 수
+
+        ExecutorService executor = Executors.newFixedThreadPool(clients);
+
+        int[] trueCount = new int[clients];
+        int[] falseCount = new int[clients];
+
+        for (int i = 0; i < clientIPs.length; i++) {
+            final int index = i;
+            executor.submit(() -> {
+                String clientIP = clientIPs[index];
+                for (int j = 0; j < requestCount; j++) {
+
+                    boolean allowed = throttlingService.allowRequest(clientIP);
+                    log.debug("요청IP : " + clientIP + " 전송 여부 :  " + allowed);
+
+                    if (allowed) trueCount[index]++;
+                    else falseCount[index]++;
+                }
+            });
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+
+
+        for (int i = 0; i < clientIPs.length; i++) {
+            log.debug("요청IP :" + clientIPs[i] + " 전송 성공 : " + trueCount[i]+"회");
+            log.debug("요청IP :" + clientIPs[i] + " 전송 실패 : " + falseCount[i]+"회");
+        }
+    }
+
+    @Test
+    public void testMaxConcurrentRequestsWithDelay() throws InterruptedException {
+
+        // 다수의 클라이언트 IP 주소를 시뮬레이트
+        String[] clientIPs = {"192.168.1.1", "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5"};
+        int clients = clientIPs.length;
+        int requestCount = 13 ; // 각 스레드가 보낼 요청 수
+
+        ExecutorService executor = Executors.newFixedThreadPool(clients);
+
+        int[] trueCount = new int[clients];
+        int[] falseCount = new int[clients];
+
+        for (int i = 0; i < clientIPs.length; i++) {
+            final int index = i;
+            executor.submit(() -> {
+                String clientIP = clientIPs[index];
+                for (int j = 0; j < requestCount; j++) {
+
+                    boolean allowed = throttlingService.allowRequest(clientIP);
+                    log.debug("요청IP : " + clientIP + " 전송 여부 :  " + allowed);
+
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    if (allowed) trueCount[index]++;
+                    else falseCount[index]++;
+                }
+            });
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+
+
+        for (int i = 0; i < clientIPs.length; i++) {
+            log.debug("요청IP :" + clientIPs[i] + " 전송 성공 : " + trueCount[i]+"회");
+            log.debug("요청IP :" + clientIPs[i] + " 전송 실패 : " + falseCount[i]+"회");
+        }
+    }
+}

--- a/src/test/java/com/gg/mafia/sample/ThrottlingTest.java
+++ b/src/test/java/com/gg/mafia/sample/ThrottlingTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.gg.mafia.domain.member.application.ThrottlingService;
+import io.github.bucket4j.Bucket;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -111,7 +113,11 @@ public class ThrottlingTest {
             log.debug("버켓사이즈: "+ throttlingService.getBuckets().size());
         }
 
+        for (Map.Entry<String, Bucket> entry : throttlingService.getBuckets().entrySet()) {
+            String ipAddress = entry.getKey();
 
+            log.debug("버킷에 저장된 IP 주소: " + ipAddress);
+        }
         // 버킷이 제대로 삭제되었는지 확인
         assertTrue(throttlingService.getBuckets().size() <= 100);
     }


### PR DESCRIPTION
## email.properties 추가 
https://www.notion.so/30315b961d684a9abfbb7e6b738a7be8


## AuthApi
 /signup : 회원가입시 유효한 인증코드인지 다시확인
- UserNotAllowedException 발생

/sendMail : 이메일 보내기 요청 

- ip주소를 받아오기 위해 HttpServletRequest 추가 요청(쓰로틀링 구현을 위함)
- 프록시 서버나 로드 밸런서를 사용할 때 (XFF) 헤더로 그 외에는 getRemoteAddr() ip 받아오기

/confirmMail : 인증코드 확인 요청

## MailService (#27)
smtp를 위한 javax.mail 의존성 추가

인증코드 생성(랜덤정수6개) 후 이메일 전송

메일,인증코드를 key,value 값으로 redis 서버에 저장

요청 IP를 바탕으로 쓰로틀링 처리

UserAlreadyExistsException : 이미 회원가입한 메일일 경우 발생(409)
MailServerException : 이메일 서버 오류(400)
RequestThrottlingException : 많은 요청 발생시 rateLimter가 오류 발생(429)

## ThrottlingService (#53)
쓰로틀링을 위한 bucket4j 의존성 추가
CocurrentLinkedHashMap을 지원하는 의존성 추가

CocurrentLinkedHashMap에 ip 당 버켓을 지정하고 maximum을 지정해 LRU방식으로 메모리 관리

이메일 전송시 tryConsume() 함수를 사용하여 1개씩 꺼내어 사용가능 여부 판별

MAX_IP_BUCKETS : 최대 충전가능 버켓수
Refill.intervally({시간당버켓충전수},{충전시간})

ThrottlingTest 
- 여러 스레드에서 한번에 많은 요청 테스트
- 여러 스레드에서 delay있는 많은 요청 테스트
- 아이피당 버켓 LRU 관리 테스트

## User에 nickname column 추가 
