### PR TITLE
Feature/game dao 59

### DIFF
--- a/src/main/java/com/gg/mafia/domain/board/api/SampleApi.java
+++ b/src/main/java/com/gg/mafia/domain/board/api/SampleApi.java
@@ -5,7 +5,7 @@ import com.gg.mafia.domain.board.dto.SampleCreateRequest;
 import com.gg.mafia.domain.board.dto.SampleResponse;
 import com.gg.mafia.domain.board.dto.SampleSearchRequest;
 import com.gg.mafia.domain.board.dto.SampleUpdateRequest;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import com.gg.mafia.global.common.response.ApiResponse;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +36,10 @@ public class SampleApi {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<Page<SampleResponse>>> search(SampleSearchRequest request, SearchFilter filter,
+    public ResponseEntity<ApiResponse<Page<SampleResponse>>> search(SampleSearchRequest request,
+                                                                    SearchQuery searchQuery,
                                                                     @PageableDefault Pageable pageable) {
-        Page<SampleResponse> result = sampleService.search(request, filter, pageable);
+        Page<SampleResponse> result = sampleService.search(request, searchQuery, pageable);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 

--- a/src/main/java/com/gg/mafia/domain/board/application/SampleService.java
+++ b/src/main/java/com/gg/mafia/domain/board/application/SampleService.java
@@ -7,7 +7,7 @@ import com.gg.mafia.domain.board.dto.SampleMapper;
 import com.gg.mafia.domain.board.dto.SampleResponse;
 import com.gg.mafia.domain.board.dto.SampleSearchRequest;
 import com.gg.mafia.domain.board.dto.SampleUpdateRequest;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +26,8 @@ public class SampleService {
         return sampleDao.findAll(pageable).map(sampleMapper::toResponse);
     }
 
-    public Page<SampleResponse> search(SampleSearchRequest request, SearchFilter filter, Pageable pageable) {
-        return sampleDao.search(request, filter, pageable).map(sampleMapper::toResponse);
+    public Page<SampleResponse> search(SampleSearchRequest request, SearchQuery searchQuery, Pageable pageable) {
+        return sampleDao.search(request, searchQuery, pageable).map(sampleMapper::toResponse);
     }
 
     public SampleResponse getById(Long id) {

--- a/src/main/java/com/gg/mafia/domain/board/dao/SampleDao.java
+++ b/src/main/java/com/gg/mafia/domain/board/dao/SampleDao.java
@@ -2,7 +2,7 @@ package com.gg.mafia.domain.board.dao;
 
 import com.gg.mafia.domain.board.domain.Sample;
 import com.gg.mafia.domain.board.dto.SampleSearchRequest;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ public interface SampleDao extends JpaRepository<Sample, Long>, SampleDaoCustom 
     Page<Sample> findAll(@NonNull Pageable pageable);
 
     @Override
-    Page<Sample> search(SampleSearchRequest dto, SearchFilter filter, @NonNull Pageable pageable);
+    Page<Sample> search(SampleSearchRequest dto, SearchQuery searchQuery, @NonNull Pageable pageable);
 
     @Override
     @NonNull

--- a/src/main/java/com/gg/mafia/domain/board/dao/SampleDaoCustom.java
+++ b/src/main/java/com/gg/mafia/domain/board/dao/SampleDaoCustom.java
@@ -2,10 +2,10 @@ package com.gg.mafia.domain.board.dao;
 
 import com.gg.mafia.domain.board.domain.Sample;
 import com.gg.mafia.domain.board.dto.SampleSearchRequest;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface SampleDaoCustom {
-    Page<Sample> search(SampleSearchRequest request, SearchFilter filter, Pageable pageable);
+    Page<Sample> search(SampleSearchRequest request, SearchQuery searchQuery, Pageable pageable);
 }

--- a/src/main/java/com/gg/mafia/domain/board/dao/SampleDaoImpl.java
+++ b/src/main/java/com/gg/mafia/domain/board/dao/SampleDaoImpl.java
@@ -3,7 +3,7 @@ package com.gg.mafia.domain.board.dao;
 import com.gg.mafia.domain.board.domain.QSample;
 import com.gg.mafia.domain.board.domain.Sample;
 import com.gg.mafia.domain.board.dto.SampleSearchRequest;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,18 +20,18 @@ public class SampleDaoImpl implements SampleDaoCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Sample> search(SampleSearchRequest request, SearchFilter filter, Pageable pageable) {
+    public Page<Sample> search(SampleSearchRequest request, SearchQuery searchQuery, Pageable pageable) {
         QSample sample = QSample.sample;
         List<Sample> samples = queryFactory
                 .selectFrom(sample)
-                .where(buildSearchCondition(filter), buildRequestCondition(request))
+                .where(buildSearchCondition(searchQuery), buildRequestCondition(request))
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
         Long count = queryFactory
                 .select(sample.count())
                 .from(sample)
-                .where(buildSearchCondition(filter), buildRequestCondition(request))
+                .where(buildSearchCondition(searchQuery), buildRequestCondition(request))
                 .fetchOne();
         if (count == null) {
             count = 0L;
@@ -39,13 +39,13 @@ public class SampleDaoImpl implements SampleDaoCustom {
         return new PageImpl<>(samples, pageable, count);
     }
 
-    private BooleanBuilder buildSearchCondition(SearchFilter filter) {
+    private BooleanBuilder buildSearchCondition(SearchQuery searchQuery) {
         return new BooleanBuilder()
-                .and(matchKeyword(filter.getKeyword()))
-                .and(matchCreatedAfter(filter.getCreatedAfter()))
-                .and(matchCreatedBefore(filter.getCreatedBefore()))
-                .and(matchUpdatedAfter(filter.getUpdatedAfter()))
-                .and(matchUpdatedBefore(filter.getUpdatedBefore()));
+                .and(matchKeyword(searchQuery.getKeyword()))
+                .and(matchCreatedAfter(searchQuery.getCreatedAfter()))
+                .and(matchCreatedBefore(searchQuery.getCreatedBefore()))
+                .and(matchUpdatedAfter(searchQuery.getUpdatedAfter()))
+                .and(matchUpdatedBefore(searchQuery.getUpdatedBefore()));
     }
 
     private BooleanBuilder buildRequestCondition(SampleSearchRequest request) {

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameDao.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameDao.java
@@ -2,6 +2,7 @@ package com.gg.mafia.domain.record.dao;
 
 import com.gg.mafia.domain.record.domain.Game;
 import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
 import com.gg.mafia.global.common.request.SearchFilter;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,7 +16,13 @@ public interface GameDao extends JpaRepository<Game, Long>, GameDaoCustom {
     Page<Game> findAll(@NonNull Pageable pageable);
 
     @Override
+    Long searchForCount(GameSearchRequest request, SearchFilter filter);
+
+    @Override
     Page<Game> search(GameSearchRequest request, SearchFilter filter, @NonNull Pageable pageable);
+
+    @Override
+    Integer getActionSuccessCount(ActionSuccessCountDto dto);
 
     @Override
     @NonNull

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameDao.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameDao.java
@@ -1,9 +1,9 @@
 package com.gg.mafia.domain.record.dao;
 
 import com.gg.mafia.domain.record.domain.Game;
-import com.gg.mafia.domain.record.dto.GameSearchRequest;
 import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.global.common.request.SearchQuery;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,10 +16,10 @@ public interface GameDao extends JpaRepository<Game, Long>, GameDaoCustom {
     Page<Game> findAll(@NonNull Pageable pageable);
 
     @Override
-    Long searchForCount(GameSearchRequest request, SearchFilter filter);
+    Long searchForCount(GameSearchRequest request, SearchQuery searchQuery);
 
     @Override
-    Page<Game> search(GameSearchRequest request, SearchFilter filter, @NonNull Pageable pageable);
+    Page<Game> search(GameSearchRequest request, SearchQuery searchQuery, @NonNull Pageable pageable);
 
     @Override
     Integer getActionSuccessCount(ActionSuccessCountDto dto);

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameDaoCustom.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameDaoCustom.java
@@ -1,17 +1,17 @@
 package com.gg.mafia.domain.record.dao;
 
 import com.gg.mafia.domain.record.domain.Game;
-import com.gg.mafia.domain.record.dto.GameSearchRequest;
 import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.global.common.request.SearchQuery;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.NonNull;
 
 public interface GameDaoCustom {
-    Long searchForCount(GameSearchRequest request, SearchFilter filter);
+    Long searchForCount(GameSearchRequest request, SearchQuery searchQuery);
 
-    Page<Game> search(GameSearchRequest request, SearchFilter filter, @NonNull Pageable pageable);
+    Page<Game> search(GameSearchRequest request, SearchQuery searchQuery, @NonNull Pageable pageable);
 
     Integer getActionSuccessCount(ActionSuccessCountDto dto);
 }

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameDaoCustom.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameDaoCustom.java
@@ -2,11 +2,16 @@ package com.gg.mafia.domain.record.dao;
 
 import com.gg.mafia.domain.record.domain.Game;
 import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
 import com.gg.mafia.global.common.request.SearchFilter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.NonNull;
 
 public interface GameDaoCustom {
+    Long searchForCount(GameSearchRequest request, SearchFilter filter);
+
     Page<Game> search(GameSearchRequest request, SearchFilter filter, @NonNull Pageable pageable);
+
+    Integer getActionSuccessCount(ActionSuccessCountDto dto);
 }

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameDaoImpl.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameDaoImpl.java
@@ -5,11 +5,11 @@ import com.gg.mafia.domain.record.domain.JobEnum;
 import com.gg.mafia.domain.record.domain.QGame;
 import com.gg.mafia.domain.record.domain.QGameParticipation;
 import com.gg.mafia.domain.record.domain.QGameRound;
+import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
 import com.gg.mafia.domain.record.dto.GameParticipationSubQueryDto;
 import com.gg.mafia.domain.record.dto.GameRoundSubQueryDto;
 import com.gg.mafia.domain.record.dto.GameSearchRequest;
-import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.global.common.request.SearchQuery;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberPath;
@@ -27,12 +27,12 @@ import org.springframework.lang.NonNull;
 public class GameDaoImpl implements GameDaoCustom {
     private final JPAQueryFactory queryFactory;
 
-    public Long searchForCount(GameSearchRequest request, SearchFilter filter) {
+    public Long searchForCount(GameSearchRequest request, SearchQuery searchQuery) {
         QGame game = QGame.game;
         Long count = queryFactory
                 .select(game.count())
                 .from(game)
-                .where(buildSearchCondition(filter), buildRequestCondition(request))
+                .where(buildSearchCondition(searchQuery), buildRequestCondition(request))
                 .fetchOne();
         if (count == null) {
             count = 0L;
@@ -40,15 +40,15 @@ public class GameDaoImpl implements GameDaoCustom {
         return count;
     }
 
-    public Page<Game> search(GameSearchRequest request, SearchFilter filter, @NonNull Pageable pageable) {
+    public Page<Game> search(GameSearchRequest request, SearchQuery searchQuery, @NonNull Pageable pageable) {
         QGame game = QGame.game;
         List<Game> games = queryFactory
                 .selectFrom(game)
-                .where(buildSearchCondition(filter), buildRequestCondition(request))
+                .where(buildSearchCondition(searchQuery), buildRequestCondition(request))
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
-        Long count = searchForCount(request, filter);
+        Long count = searchForCount(request, searchQuery);
         return new PageImpl<>(games, pageable, count);
     }
 
@@ -78,12 +78,12 @@ public class GameDaoImpl implements GameDaoCustom {
                 .fetchOne();
     }
 
-    private BooleanBuilder buildSearchCondition(SearchFilter filter) {
+    private BooleanBuilder buildSearchCondition(SearchQuery searchQuery) {
         return new BooleanBuilder()
-                .and(matchCreatedAfter(filter.getCreatedAfter()))
-                .and(matchCreatedBefore(filter.getCreatedBefore()))
-                .and(matchUpdatedAfter(filter.getUpdatedAfter()))
-                .and(matchUpdatedBefore(filter.getUpdatedBefore()));
+                .and(matchCreatedAfter(searchQuery.getCreatedAfter()))
+                .and(matchCreatedBefore(searchQuery.getCreatedBefore()))
+                .and(matchUpdatedAfter(searchQuery.getUpdatedAfter()))
+                .and(matchUpdatedBefore(searchQuery.getUpdatedBefore()));
     }
 
     private BooleanBuilder buildRequestCondition(GameSearchRequest request) {

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameRoundDao.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameRoundDao.java
@@ -1,0 +1,18 @@
+package com.gg.mafia.domain.record.dao;
+
+import com.gg.mafia.domain.record.domain.GameRound;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
+
+public interface GameRoundDao extends JpaRepository<GameRound, Long> {
+    @Override
+    @NonNull
+    Page<GameRound> findAll(@NonNull Pageable pageable);
+
+    @Override
+    @NonNull
+    Optional<GameRound> findById(@NonNull Long id);
+}

--- a/src/main/java/com/gg/mafia/domain/record/domain/Game.java
+++ b/src/main/java/com/gg/mafia/domain/record/domain/Game.java
@@ -34,6 +34,9 @@ public class Game extends BaseEntity {
     @OneToMany(mappedBy = "game", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.LAZY)
     private List<GameParticipation> gameParticipations = new ArrayList<>();
 
+    @OneToMany(mappedBy = "game", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.LAZY)
+    private List<GameRound> gameRounds = new ArrayList<>();
+
     @Builder
     public Game(Integer round, Boolean mafiaWon) {
         this.round = round;

--- a/src/main/java/com/gg/mafia/domain/record/domain/GameRound.java
+++ b/src/main/java/com/gg/mafia/domain/record/domain/GameRound.java
@@ -1,0 +1,73 @@
+package com.gg.mafia.domain.record.domain;
+
+import com.gg.mafia.domain.member.domain.User;
+import com.gg.mafia.domain.model.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        columnNames = {"round", "game_id"}
+                )
+        }
+)
+public class GameRound extends BaseEntity {
+    @Column(nullable = false)
+    private Integer round;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST})
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Game game;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST})
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User votedPlayer;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST})
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User killedPlayer;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST})
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User curedPlayer;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST})
+    @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User detectedPlayer;
+
+
+    @Builder
+    public GameRound(Integer round, Game game, User votedPlayer, User killedPlayer, User curedPlayer,
+                     User detectedPlayer) {
+        this.round = round;
+        this.votedPlayer = votedPlayer;
+        this.killedPlayer = killedPlayer;
+        this.curedPlayer = curedPlayer;
+        this.detectedPlayer = detectedPlayer;
+        setGame(game);
+    }
+
+    public void setGame(Game game) {
+        if (this.game != null) {
+            this.game.getGameRounds().remove(this);
+        }
+        this.game = game;
+        this.game.getGameRounds().add(this);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/record/domain/JobEnumDeserializer.java
+++ b/src/main/java/com/gg/mafia/domain/record/domain/JobEnumDeserializer.java
@@ -1,0 +1,20 @@
+package com.gg.mafia.domain.record.domain;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+
+public class JobEnumDeserializer extends JsonDeserializer<JobEnum> {
+
+    @Override
+    public JobEnum deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        ObjectCodec oc = jsonParser.getCodec();
+        JsonNode node = oc.readTree(jsonParser);
+        String job = node.textValue();
+        return JobEnum.valueOf(job);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/record/dto/ActionSuccessCountDto.java
+++ b/src/main/java/com/gg/mafia/domain/record/dto/ActionSuccessCountDto.java
@@ -1,0 +1,23 @@
+package com.gg.mafia.domain.record.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.gg.mafia.domain.record.domain.JobEnum;
+import com.gg.mafia.domain.record.domain.JobEnumDeserializer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ActionSuccessCountDto {
+    private Long userId;
+
+    @JsonDeserialize(using = JobEnumDeserializer.class)
+    private JobEnum job;
+
+    @JsonDeserialize(using = JobEnumDeserializer.class)
+    private JobEnum actionBy;
+}

--- a/src/main/java/com/gg/mafia/domain/record/dto/GameParticipationSubQueryDto.java
+++ b/src/main/java/com/gg/mafia/domain/record/dto/GameParticipationSubQueryDto.java
@@ -1,0 +1,22 @@
+package com.gg.mafia.domain.record.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.gg.mafia.domain.record.domain.JobEnum;
+import com.gg.mafia.domain.record.domain.JobEnumDeserializer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GameParticipationSubQueryDto {
+    private Long userId;
+
+    @JsonDeserialize(using = JobEnumDeserializer.class)
+    private JobEnum job;
+
+    private Boolean survival;
+}

--- a/src/main/java/com/gg/mafia/domain/record/dto/GameRoundSubQueryDto.java
+++ b/src/main/java/com/gg/mafia/domain/record/dto/GameRoundSubQueryDto.java
@@ -1,0 +1,20 @@
+package com.gg.mafia.domain.record.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GameRoundSubQueryDto {
+    private Long votedPlayerId;
+
+    private Long killedPlayerId;
+
+    private Long curedPlayerId;
+
+    private Long detectedPlayerId;
+}

--- a/src/main/java/com/gg/mafia/domain/record/dto/GameSearchRequest.java
+++ b/src/main/java/com/gg/mafia/domain/record/dto/GameSearchRequest.java
@@ -1,5 +1,8 @@
 package com.gg.mafia.domain.record.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.gg.mafia.domain.record.domain.JobEnum;
+import com.gg.mafia.domain.record.domain.JobEnumDeserializer;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,4 +42,17 @@ public class GameSearchRequest {
     private Integer detectSuccessCountLte;
 
     private Long userId;
+
+    private Boolean survival;
+
+    @JsonDeserialize(using = JobEnumDeserializer.class)
+    private JobEnum job;
+
+    private Long votedPlayerId;
+
+    private Long killedPlayerId;
+
+    private Long curedPlayerId;
+
+    private Long detectedPlayerId;
 }

--- a/src/main/java/com/gg/mafia/global/common/request/SearchQuery.java
+++ b/src/main/java/com/gg/mafia/global/common/request/SearchQuery.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class SearchFilter {
+public class SearchQuery {
     private String keyword;
     private LocalDateTime createdAfter;
     private LocalDateTime createdBefore;

--- a/src/test/java/com/gg/mafia/domain/record/dao/GameDaoTest.java
+++ b/src/test/java/com/gg/mafia/domain/record/dao/GameDaoTest.java
@@ -3,7 +3,10 @@ package com.gg.mafia.domain.record.dao;
 import com.gg.mafia.domain.member.domain.User;
 import com.gg.mafia.domain.record.domain.Game;
 import com.gg.mafia.domain.record.domain.GameParticipation;
+import com.gg.mafia.domain.record.domain.GameRound;
+import com.gg.mafia.domain.record.domain.JobEnum;
 import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
 import com.gg.mafia.global.common.request.SearchFilter;
 import com.gg.mafia.global.config.AppConfig;
 import com.gg.mafia.global.config.auditing.AuditingConfig;
@@ -11,6 +14,7 @@ import com.gg.mafia.global.config.db.TestDbConfig;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
@@ -33,10 +37,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Slf4j
 public class GameDaoTest {
+    private final Random rand;
     @Autowired
     GameDao gameDao;
-
-    private final Random rand;
 
     public GameDaoTest() {
         this.rand = new Random();
@@ -135,6 +138,124 @@ public class GameDaoTest {
         Assertions.assertThat(playedGamesFromDb).isEqualTo(playedGames);
     }
 
+    @Test
+    @DisplayName("게임 기록 조회 테스트 - 마피아 직업으로 참여한 Game 데이터의 killSuccessCount의 합")
+    public void testGetKillSuccessCountPlayingMafia() {
+        // Given
+        int gameNumber = 10;
+        List<Game> games = createGames(gameNumber);
+        User user = createUser(0);
+        List<GameParticipation> gameParticipations = createGameParticipations(user, games);
+        Integer playerActionCount = gameParticipations.stream()
+                .filter(gameParticipation -> gameParticipation.getJob().equals(JobEnum.MAFIA))
+                .mapToInt(gameParticipation -> gameParticipation.getGame().getKillSuccessCount())
+                .sum();
+        gameDao.saveAll(games);
+
+        // When
+        ActionSuccessCountDto dto = ActionSuccessCountDto.builder()
+                .userId(user.getId())
+                .actionBy(JobEnum.MAFIA)
+                .job(JobEnum.MAFIA)
+                .build();
+        Integer playerActionCountFromDb = gameDao.getActionSuccessCount(dto);
+
+        // Then
+        Assertions.assertThat(playerActionCountFromDb).isEqualTo(playerActionCount);
+    }
+
+    @Test
+    @DisplayName("게임 기록 조회 테스트 - 마피아 직업으로 참여하여 투표로 죽은 게임 횟수")
+    public void testGetVotedGamesPlayingMafia() {
+        // Given
+        int gameNumber = 20;
+        List<Game> games = createGames(gameNumber);
+        User user = createUser(0);
+        List<GameParticipation> gameParticipations = createGameParticipations(user, games);
+        games.forEach(game -> createGameRounds(game, List.of(user), rand.nextInt(10)));
+        Long votedGames = gameParticipations.stream()
+                .filter(gameParticipation -> gameParticipation.getJob().equals(JobEnum.MAFIA))
+                .filter(gameParticipation -> {
+                    List<GameRound> grs = gameParticipation.getGame().getGameRounds();
+                    return grs.stream()
+                            .map(gameRound -> gameRound.getVotedPlayer() != null && gameRound.getVotedPlayer()
+                                    .equals(user))
+                            .reduce(false, (e1, e2) -> e1 || e2);
+                })
+                .count();
+        gameDao.saveAll(games);
+
+        // When
+        GameSearchRequest request = GameSearchRequest.builder()
+                .userId(user.getId())
+                .job(JobEnum.MAFIA)
+                .votedPlayerId(user.getId())
+                .build();
+        Long votedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+
+        // Then
+        Assertions.assertThat(votedGamesFromDb).isEqualTo(votedGames);
+    }
+
+    @Test
+    @DisplayName("게임 기록 조회 테스트 - 마피아 직업으로 참여하여 생존한 게임 횟수")
+    public void testSurvivedGamesPlayingMafia() {
+        // Given
+        int gameNumber = 20;
+        List<Game> games = createGames(gameNumber);
+        User user = createUser(0);
+        List<GameParticipation> gameParticipations = createGameParticipations(user, games);
+        Long survivedGames = gameParticipations.stream()
+                .filter(gameParticipation -> gameParticipation.getJob().equals(JobEnum.MAFIA))
+                .filter(GameParticipation::getSurvival)
+                .count();
+        gameDao.saveAll(games);
+
+        // When
+        GameSearchRequest request = GameSearchRequest.builder()
+                .userId(user.getId())
+                .job(JobEnum.MAFIA)
+                .survival(true)
+                .build();
+        Long survivedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+
+        // Then
+        Assertions.assertThat(survivedGamesFromDb).isEqualTo(survivedGames);
+    }
+
+    @Test
+    @DisplayName("게임 기록 조회 테스트 - 마피아 직업으로 참여하여 경찰에게 걸린 적이 있는 게임 횟수")
+    public void testGetDetectedGamesPlayingMafia() {
+        // Given
+        int gameNumber = 20;
+        List<Game> games = createGames(gameNumber);
+        User user = createUser(0);
+        List<GameParticipation> gameParticipations = createGameParticipations(user, games);
+        games.forEach(game -> createGameRounds(game, List.of(user), rand.nextInt(10)));
+        Long detectedGames = gameParticipations.stream()
+                .filter(gameParticipation -> gameParticipation.getJob().equals(JobEnum.MAFIA))
+                .filter(gameParticipation -> {
+                    List<GameRound> grs = gameParticipation.getGame().getGameRounds();
+                    return grs.stream()
+                            .map(gameRound -> gameRound.getDetectedPlayer() != null && gameRound.getDetectedPlayer()
+                                    .equals(user))
+                            .reduce(false, (e1, e2) -> e1 || e2);
+                })
+                .count();
+        gameDao.saveAll(games);
+
+        // When
+        GameSearchRequest request = GameSearchRequest.builder()
+                .userId(user.getId())
+                .job(JobEnum.MAFIA)
+                .detectedPlayerId(user.getId())
+                .build();
+        Long detectedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+
+        // Then
+        Assertions.assertThat(detectedGamesFromDb).isEqualTo(detectedGames);
+    }
+
     private List<Game> saveGames(int number) {
         List<Game> games = createGames(number);
         gameDao.saveAll(games);
@@ -159,10 +280,14 @@ public class GameDaoTest {
     }
 
     private Game createGame() {
-        return Game.builder()
+        Game game = Game.builder()
                 .round(rand.nextInt(1, 10))
                 .mafiaWon(rand.nextBoolean())
                 .build();
+        game.setKillSuccessCount(rand.nextInt(5));
+        game.setCureSuccessCount(rand.nextInt(5));
+        game.setDetectSuccessCount(rand.nextInt(5));
+        return game;
     }
 
     private User createUser(int idx) {
@@ -176,6 +301,42 @@ public class GameDaoTest {
         return GameParticipation.builder()
                 .user(user)
                 .game(game)
+                .job(getRandomJob())
+                .survival(rand.nextBoolean())
                 .build();
+    }
+
+    private List<GameRound> createGameRounds(Game game, List<User> users, int lastRound) {
+        return IntStream.range(1, lastRound)
+                .mapToObj((round) -> createGameRound(game, users, round))
+                .toList();
+    }
+
+    private GameRound createGameRound(Game game, List<User> users, int round) {
+        return GameRound.builder()
+                .game(game)
+                .round(round)
+                .votedPlayer(getRandomUserOrNull(users))
+                .killedPlayer(getRandomUserOrNull(users))
+                .curedPlayer(getRandomUserOrNull(users))
+                .detectedPlayer(getRandomUserOrNull(users))
+                .build();
+    }
+
+    private User getRandomUserOrNull(List<User> users) {
+        if (rand.nextBoolean()) {
+            return null;
+        }
+        return getRandomUser(users);
+    }
+
+    private User getRandomUser(List<User> users) {
+        int userIndex = rand.nextInt(users.size());
+        return users.get(userIndex);
+    }
+
+    private JobEnum getRandomJob() {
+        int jobIndex = rand.nextInt(JobEnum.values().length);
+        return JobEnum.getByValue(jobIndex);
     }
 }

--- a/src/test/java/com/gg/mafia/domain/record/dao/GameDaoTest.java
+++ b/src/test/java/com/gg/mafia/domain/record/dao/GameDaoTest.java
@@ -5,9 +5,9 @@ import com.gg.mafia.domain.record.domain.Game;
 import com.gg.mafia.domain.record.domain.GameParticipation;
 import com.gg.mafia.domain.record.domain.GameRound;
 import com.gg.mafia.domain.record.domain.JobEnum;
-import com.gg.mafia.domain.record.dto.GameSearchRequest;
 import com.gg.mafia.domain.record.dto.ActionSuccessCountDto;
-import com.gg.mafia.global.common.request.SearchFilter;
+import com.gg.mafia.domain.record.dto.GameSearchRequest;
+import com.gg.mafia.global.common.request.SearchQuery;
 import com.gg.mafia.global.config.AppConfig;
 import com.gg.mafia.global.config.auditing.AuditingConfig;
 import com.gg.mafia.global.config.db.TestDbConfig;
@@ -80,9 +80,9 @@ public class GameDaoTest {
         GameSearchRequest request = GameSearchRequest.builder()
                 .mafiaWon(true)
                 .build();
-        SearchFilter filter = SearchFilter.builder().build();
+        SearchQuery searchQuery = SearchQuery.builder().build();
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Game> mafiaWonGames = gameDao.search(request, filter, pageable);
+        Page<Game> mafiaWonGames = gameDao.search(request, searchQuery, pageable);
         int mafiaWonCountFromDb = (int) mafiaWonGames.stream().filter(Game::getMafiaWon).count();
 
         // Then
@@ -102,9 +102,9 @@ public class GameDaoTest {
         GameSearchRequest request = GameSearchRequest.builder()
                 .roundGte(3)
                 .build();
-        SearchFilter filter = SearchFilter.builder().build();
+        SearchQuery searchQuery = SearchQuery.builder().build();
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Game> mafiaWonGames = gameDao.search(request, filter, pageable);
+        Page<Game> mafiaWonGames = gameDao.search(request, searchQuery, pageable);
         int matchCountFromDb = (int) mafiaWonGames.stream().filter(condition).count();
 
         // Then
@@ -128,9 +128,9 @@ public class GameDaoTest {
         GameSearchRequest request = GameSearchRequest.builder()
                 .userId(user.getId())
                 .build();
-        SearchFilter filter = SearchFilter.builder().build();
+        SearchQuery searchQuery = SearchQuery.builder().build();
         Pageable pageable = PageRequest.of(0, 10);
-        List<Game> playedGamesFromDb = gameDao.search(request, filter, pageable)
+        List<Game> playedGamesFromDb = gameDao.search(request, searchQuery, pageable)
                 .get()
                 .toList();
 
@@ -191,7 +191,7 @@ public class GameDaoTest {
                 .job(JobEnum.MAFIA)
                 .votedPlayerId(user.getId())
                 .build();
-        Long votedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+        Long votedGamesFromDb = gameDao.searchForCount(request, SearchQuery.builder().build());
 
         // Then
         Assertions.assertThat(votedGamesFromDb).isEqualTo(votedGames);
@@ -217,7 +217,7 @@ public class GameDaoTest {
                 .job(JobEnum.MAFIA)
                 .survival(true)
                 .build();
-        Long survivedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+        Long survivedGamesFromDb = gameDao.searchForCount(request, SearchQuery.builder().build());
 
         // Then
         Assertions.assertThat(survivedGamesFromDb).isEqualTo(survivedGames);
@@ -250,7 +250,7 @@ public class GameDaoTest {
                 .job(JobEnum.MAFIA)
                 .detectedPlayerId(user.getId())
                 .build();
-        Long detectedGamesFromDb = gameDao.searchForCount(request, SearchFilter.builder().build());
+        Long detectedGamesFromDb = gameDao.searchForCount(request, SearchQuery.builder().build());
 
         // Then
         Assertions.assertThat(detectedGamesFromDb).isEqualTo(detectedGames);


### PR DESCRIPTION
### feat: GameRound DAO, Entity 추가

게임의 각 라운드 별 결과 기록이 담긴 엔티티와 DAO를 구현

### feat: 업적 해방 조건 확인을 위해 게임 기록 DAO 업데이트

- GameDao.searchForCount(): 검색 결과에 대한 Game 엔티티 카운트 값을 반환하는 함수

- GameDao.getActionSuccessCount(): 직업 행동 성공 횟수에 대한 집계 쿼리 실행 함수

- GameParticipationSubQueryDto, GameRoundSubQueryDto: 게임 DAO에서 게임 참가 기록, 게임 라운드 기록에 대한 서브 쿼리를 만들기 위한 DTO

- GameSearchRequest: 게임 DAO에서 서브 쿼리를 위한 필드를 해당 DTO에서 추가

- JobEnumDeserializer: 직업 Enum 파라미터를 API에서 쿼리 파라미터로 받을 시 역직렬화 가능하도록 역직렬화기 구현

### test: 업적 해방 조건 확인을 위해 게임 기록 DAO 업데이트 사항 테스트

- testGetKillSuccessCountPlayingMafia(): 마피아 직업으로 참여한 Game 데이터의 killSuccessCount의 합
- testGetVotedGamesPlayingMafia(): 마피아 직업으로 참여하여 투표로 죽은 게임 횟수
- testSurvivedGamesPlayingMafia(): 마피아 직업으로 참여하여 생존한 게임 횟수
- testGetDetectedGamesPlayingMafia(): 마피아 직업으로 참여하여 경찰에게 걸린 적이 있는 게임 횟수

### refactor: SearchFilter -> SearchQuery

공통 검색 DTO 네이밍을 명확하게 변경