### PR TITLE
feat : Following Api 구현

### DIFF
--- a/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
@@ -31,7 +31,7 @@ public class FollowingApi {
     @GetMapping("/follow/followers")
     public ResponseEntity<ApiResponse<List<Following>>> showFollowers(Principal principal,
                                                                       @RequestParam String email) {
-        List<Following> followees = followingService.getFollowees(email);
+        List<Following> followees = followingService.getFollowers(email);
         return ResponseEntity.ok(ApiResponse.success(followees));
     }
 

--- a/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
@@ -1,12 +1,49 @@
 package com.gg.mafia.domain.member.api;
 
+import com.gg.mafia.domain.member.application.FollowingService;
+import com.gg.mafia.domain.member.domain.Following;
+import com.gg.mafia.global.common.response.ApiResponse;
+import java.security.Principal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
 public class FollowingApi {
-    private final FollowingSer
+    private final FollowingService followingService;
+
+    @GetMapping("/follow/followees")
+    public ResponseEntity<ApiResponse<List<Following>>> showFollowees(Principal principal,
+                                                                      @RequestParam String email) {
+        List<Following> followees = followingService.getFollowees(email);
+        return ResponseEntity.ok(ApiResponse.success(followees));
+    }
+
+    @GetMapping("/follow/followers")
+    public ResponseEntity<ApiResponse<List<Following>>> showFollowers(Principal principal,
+                                                                      @RequestParam String email) {
+        List<Following> followees = followingService.getFollowees(email);
+        return ResponseEntity.ok(ApiResponse.success(followees));
+    }
+
+    @PostMapping("/follow")
+    public ResponseEntity<ApiResponse<Void>> addFollow(Principal principal, @RequestBody String followeeEmail) {
+        followingService.insertFollowing(principal.getName(), followeeEmail);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/follow")
+    public ResponseEntity<ApiResponse<Void>> removeFollow(Principal principal, @RequestBody String followeeEmail) {
+        followingService.removeFollowee(principal.getName(), followeeEmail);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
+++ b/src/main/java/com/gg/mafia/domain/member/api/FollowingApi.java
@@ -1,0 +1,12 @@
+package com.gg.mafia.domain.member.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class FollowingApi {
+    private final FollowingSer
+}

--- a/src/test/java/com/gg/mafia/domain/member/api/FollowingApiTest.java
+++ b/src/test/java/com/gg/mafia/domain/member/api/FollowingApiTest.java
@@ -1,2 +1,106 @@
 package com.gg.mafia.domain.member.api;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.gg.mafia.domain.member.application.FollowingService;
+import com.gg.mafia.domain.member.domain.Following;
+import com.gg.mafia.domain.member.domain.User;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class FollowingApiTest {
+    @InjectMocks
+    FollowingApi followingApi;
+    @Mock
+    FollowingService followingService;
+    @Mock
+    Principal principal;
+    MockMvc mockMvc;
+    User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = createUser("TEST@naver.com", "123");
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(followingApi).build();
+    }
+
+    @Test
+    void showFollowees() throws Exception {
+        mockMvc.perform(get("/member/follow/followees")
+                        .param("email", user.getEmail()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void showFollowers() throws Exception {
+        mockMvc.perform(get("/member/follow/followers")
+                        .param("email", user.getEmail()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void addFollow() throws Exception {
+        given(principal.getName()).willReturn(user.getEmail());
+
+        mockMvc.perform(post("/member/follow")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"followeeEmail\" : \"%s\"}", user.getEmail()))
+                        .principal(principal)
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void removeFollow() throws Exception {
+        given(principal.getName()).willReturn(user.getEmail());
+
+        mockMvc.perform(delete("/member/follow")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"followeeEmail\" : \"%s\"}", user.getEmail()))
+                        .principal(principal)
+                )
+                .andExpect(status().isOk());
+    }
+
+    private User createUser(String email, String pw) {
+        return User.builder().email(email).password(pw).build();
+    }
+
+    private List<Following> createFollowingsFromFollower(User follower, int count) {
+        Random rand = new Random();
+        List<Following> followings = new ArrayList<>();
+        for (int i = 1; i < count; i++) {
+            User randomFollowee = createUser(UUID.randomUUID().toString().substring(0, 5), "123");
+            if (rand.nextInt(1, 10) > 5) {
+                followings.add(createFollowing(follower, randomFollowee));
+            } else {
+                User randomFollower = createUser(UUID.randomUUID().toString().substring(0, 5), "123");
+                followings.add(createFollowing(randomFollower, randomFollowee));
+            }
+        }
+        return followings;
+    }
+
+    private Following createFollowing(User follower, User followee) {
+        return Following.builder().follower(follower).followee(followee).build();
+    }
+}

--- a/src/test/java/com/gg/mafia/domain/member/api/FollowingApiTest.java
+++ b/src/test/java/com/gg/mafia/domain/member/api/FollowingApiTest.java
@@ -1,0 +1,2 @@
+package com.gg.mafia.domain.member.api;
+


### PR DESCRIPTION
## 생성
- url : /member/follow
- method : POST
- request body : followeeEmail 


## 삭제
- url : /member/follow
- method : DELETE
- request body : followeeEmail

## 조회 (특정 사용자가 팔로잉한 리스트)
- url : /member/follow/followees
- methdo : GET
- request parameter : email

## 조회 (특정 사용자를 팔로잉한 리스트)
- url : /member/follow/followers
- methdo : GET
- request parameter : email