### PR TITLE
Feature/game history 111

### DIFF
--- a/src/main/java/com/gg/mafia/domain/record/api/GameHistoryApi.java
+++ b/src/main/java/com/gg/mafia/domain/record/api/GameHistoryApi.java
@@ -1,0 +1,27 @@
+package com.gg.mafia.domain.record.api;
+
+import com.gg.mafia.domain.record.application.GameHistoryService;
+import com.gg.mafia.domain.record.dto.GameHistoryResponse;
+import com.gg.mafia.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/record/users")
+@RequiredArgsConstructor
+public class GameHistoryApi {
+    private final GameHistoryService gameHistoryService;
+
+    @GetMapping("/{userId}/histories")
+    public ResponseEntity<ApiResponse<Page<GameHistoryResponse>>> getAll(Long userId,
+                                                                         @PageableDefault Pageable pageable) {
+        Page<GameHistoryResponse> result = gameHistoryService.getAll(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/record/application/GameHistoryService.java
+++ b/src/main/java/com/gg/mafia/domain/record/application/GameHistoryService.java
@@ -1,0 +1,18 @@
+package com.gg.mafia.domain.record.application;
+
+import com.gg.mafia.domain.record.dao.GameHistoryDao;
+import com.gg.mafia.domain.record.dto.GameHistoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GameHistoryService {
+    private final GameHistoryDao gameHistoryDao;
+
+    public Page<GameHistoryResponse> getAll(Long userId, Pageable pageable) {
+        return gameHistoryDao.findAll(userId, pageable);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/record/dao/GameHistoryDao.java
+++ b/src/main/java/com/gg/mafia/domain/record/dao/GameHistoryDao.java
@@ -1,0 +1,58 @@
+package com.gg.mafia.domain.record.dao;
+
+import com.gg.mafia.domain.record.domain.QGame;
+import com.gg.mafia.domain.record.domain.QGameParticipation;
+import com.gg.mafia.domain.record.dto.GameHistoryResponse;
+import com.gg.mafia.domain.record.dto.QGameHistoryResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GameHistoryDao {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<GameHistoryResponse> findAll(Long userId, Pageable pageable) {
+        QGame game = QGame.game;
+        QGameParticipation gameParticipation = QGameParticipation.gameParticipation;
+
+        List<Long> gameParticipationIds = queryFactory
+                .select(gameParticipation.id)
+                .from(gameParticipation)
+                .where(gameParticipation.user.id.eq(userId))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        List<GameHistoryResponse> result = queryFactory
+                .select(new QGameHistoryResponse(
+                        game.id,
+                        game.createdAt,
+                        game.updatedAt,
+                        game.round,
+                        game.mafiaWon,
+                        gameParticipation.survival,
+                        gameParticipation.job
+                ))
+                .from(gameParticipation)
+                .innerJoin(gameParticipation.game, game)
+                .where(gameParticipation.id.in(gameParticipationIds))
+                .fetch();
+
+        Long count = queryFactory
+                .select(gameParticipation.count())
+                .from(gameParticipation)
+                .where(gameParticipation.user.id.eq(userId))
+                .fetchOne();
+        if (count == null) {
+            count = 0L;
+        }
+
+        return new PageImpl<>(result, pageable, count);
+    }
+}

--- a/src/main/java/com/gg/mafia/domain/record/dto/GameHistoryResponse.java
+++ b/src/main/java/com/gg/mafia/domain/record/dto/GameHistoryResponse.java
@@ -1,0 +1,49 @@
+package com.gg.mafia.domain.record.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.gg.mafia.domain.record.domain.JobEnum;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Builder
+public class GameHistoryResponse {
+    private Long id;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    private LocalDateTime updatedAt;
+
+    private Integer totalRound;
+
+    private Boolean mafiaWon;
+
+    private Boolean survival;
+
+    private JobEnum job;
+
+    @QueryProjection
+    public GameHistoryResponse(
+            Long id,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            Integer totalRound,
+            Boolean mafiaWon,
+            Boolean survival,
+            JobEnum job
+    ) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.totalRound = totalRound;
+        this.mafiaWon = mafiaWon;
+        this.survival = survival;
+        this.job = job;
+    }
+}

--- a/src/main/java/com/gg/mafia/global/config/db/DbConfig.java
+++ b/src/main/java/com/gg/mafia/global/config/db/DbConfig.java
@@ -7,19 +7,28 @@ import javax.sql.DataSource;
 import lombok.AllArgsConstructor;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @Import(QueryDslConfig.class)
 @EnableJpaRepositories("com.gg.mafia")
+@ComponentScan(
+        basePackages = "com.gg.mafia",
+        useDefaultFilters = false,
+        includeFilters = @Filter(type = FilterType.ANNOTATION, classes = Repository.class)
+)
 @EnableTransactionManagement
 @AllArgsConstructor
 public class DbConfig {

--- a/src/test/java/com/gg/mafia/domain/record/GameDummyDataTest.java
+++ b/src/test/java/com/gg/mafia/domain/record/GameDummyDataTest.java
@@ -1,0 +1,134 @@
+package com.gg.mafia.domain.record;
+
+import com.gg.mafia.domain.member.dao.UserDao;
+import com.gg.mafia.domain.member.domain.QUser;
+import com.gg.mafia.domain.member.domain.User;
+import com.gg.mafia.domain.record.dao.GameDao;
+import com.gg.mafia.domain.record.domain.Game;
+import com.gg.mafia.domain.record.domain.GameParticipation;
+import com.gg.mafia.domain.record.domain.GameRound;
+import com.gg.mafia.domain.record.domain.JobEnum;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration("file:src/main/webapp/WEB-INF/root-context.xml")
+@Slf4j
+public class GameDummyDataTest {
+    @Autowired
+    JPAQueryFactory queryFactory;
+
+    @Autowired
+    GameDao gameDao;
+
+    @Autowired
+    UserDao userDao;
+
+    Random rand;
+
+    public GameDummyDataTest() {
+        this.rand = new Random();
+    }
+
+    @Disabled
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    public void saveGames() {
+        Long userId = queryFactory.selectFrom(QUser.user).limit(1).offset(0).fetchOne().getId();
+        User user = userDao.findById(userId).get();
+        List<Game> games = createGames(10);
+        createGameParticipations(user, games);
+        games.forEach(game -> createGameRounds(game, List.of(user), rand.nextInt(8)));
+        gameDao.saveAll(games);
+    }
+
+    private List<Game> saveGames(int number) {
+        List<Game> games = createGames(number);
+        gameDao.saveAll(games);
+        return games;
+    }
+
+    private Game saveGame() {
+        Game game = createGame();
+        return gameDao.save(game);
+    }
+
+    private List<Game> createGames(int number) {
+        return Stream.generate(this::createGame)
+                .limit(number)
+                .toList();
+    }
+
+    private List<GameParticipation> createGameParticipations(User user, List<Game> games) {
+        return games.stream()
+                .map(game -> createGameParticipation(user, game))
+                .toList();
+    }
+
+    private Game createGame() {
+        Game game = Game.builder()
+                .round(rand.nextInt(1, 10))
+                .mafiaWon(rand.nextBoolean())
+                .build();
+        game.setKillSuccessCount(rand.nextInt(5));
+        game.setCureSuccessCount(rand.nextInt(5));
+        game.setDetectSuccessCount(rand.nextInt(5));
+        return game;
+    }
+
+    private GameParticipation createGameParticipation(User user, Game game) {
+        return GameParticipation.builder()
+                .user(user)
+                .game(game)
+                .job(getRandomJob())
+                .survival(rand.nextBoolean())
+                .build();
+    }
+
+    private List<GameRound> createGameRounds(Game game, List<User> users, int lastRound) {
+        return IntStream.range(1, lastRound)
+                .mapToObj((round) -> createGameRound(game, users, round))
+                .toList();
+    }
+
+    private GameRound createGameRound(Game game, List<User> users, int round) {
+        return GameRound.builder()
+                .game(game)
+                .round(round)
+                .votedPlayer(getRandomUserOrNull(users))
+                .killedPlayer(getRandomUserOrNull(users))
+                .curedPlayer(getRandomUserOrNull(users))
+                .detectedPlayer(getRandomUserOrNull(users))
+                .build();
+    }
+
+    private User getRandomUserOrNull(List<User> users) {
+        if (rand.nextBoolean()) {
+            return null;
+        }
+        return getRandomUser(users);
+    }
+
+    private User getRandomUser(List<User> users) {
+        int userIndex = rand.nextInt(users.size());
+        return users.get(userIndex);
+    }
+
+    private JobEnum getRandomJob() {
+        int jobIndex = rand.nextInt(JobEnum.values().length);
+        return JobEnum.getByValue(jobIndex);
+    }
+}


### PR DESCRIPTION
### feat: JpaRepository가 아닌 DAO도 스캔

JpaRepository 상속방식이 아닌 @Repository로 지정된 DAO도 컴포넌트 스캔되도록 함

### feat: 유저별 게임 이력 조회 DAO 구현

- GameHistoryDao: 유저별 게임 이력 조회 DAO
- GameHistoryResponse: QueryDSL 조회 결과를 프로젝션할 DTO

### feat: 유저별 게임 이력 조회 Service, API 구현

### test: 게임 더미 데이터 추가용 테스트

- 더미 데이터 추가용
- 통합 테스트에서 제외